### PR TITLE
Ensure compatibility with ansible versions older than 1.9

### DIFF
--- a/roles/server/tasks/plugins.yml
+++ b/roles/server/tasks/plugins.yml
@@ -2,7 +2,7 @@
 
 - name: Download install GOCD Plugins
   get_url: url="{{ item }}" dest="{{ GOCD_SERVER_PLUGIN }}"
-  become_user: "{{ GOCD_USER }}"
+  sudo_user: "{{ GOCD_USER }}"
   with_items: GOCD_PLUGINS_INSTALL
   notify:
    - restart go-server
@@ -10,6 +10,6 @@
 - name: Remove GOCD  Plugins
   file: path="{{ GOCD_SERVER_PLUGIN }}/{{ item | basename }}" state=absent
   with_items: GOCD_PLUGINS_REMOVE
-  become: yes
+  sudo: yes
   notify:
    - restart go-server


### PR DESCRIPTION
Ansible 1.8 does not have ``become`` and ``become_user``. Since they are simply aliases in most cases, we can support 1.8 by not using them.

(recreated a PR from a separate branch, instead of master)