### PR TITLE
If no value is present, print nothing instead of "None"

### DIFF
--- a/roles/agent/templates/go-agent-defaults
+++ b/roles/agent/templates/go-agent-defaults
@@ -1,5 +1,5 @@
 # {{ ansible_managed }}
-{{GOCD_AGENT_ADDITIONAL_DEFAULTS}}
+{{GOCD_AGENT_ADDITIONAL_DEFAULTS | default("") }}
 
 export GO_SERVER={{ GOCD_SERVER_HOST }}
 export GO_SERVER_PORT={{ GOCD_SERVER_PORT }}


### PR DESCRIPTION
This missing default caused an error in my setup (command not found: None). Same pattern as go-server-defaults.