### PR TITLE
Fix missing variable GOCD_DEBIAN_REPOSITORY

### DIFF
--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -1,3 +1,4 @@
+GOCD_DEBIAN_REPOSITORY: http://dl.bintray.com/gocd/gocd-deb/
 GOCD_GO_VERSION: latest
 GOCD_JAVA_HOME: /usr/lib/jvm/java
 GOCD_AGENT_INSTANCES: "{{ ansible_processor_count * ansible_processor_cores }}"


### PR DESCRIPTION
Just found this bug while running Vagrant Up. The default role does not have this variable and it is ran first, so it breaks when setting the repository for apt.
