### PR TITLE
Fix #47: handler 'restart go service' fails on Ansible 2.2

### DIFF
--- a/roles/agent/handlers/main.yml
+++ b/roles/agent/handlers/main.yml
@@ -14,7 +14,7 @@
 
 - name: restart go service
   service: "name={{ item | basename }} state=restarted"
-  with_items: go_services.stdout_lines
+  with_items: "{{ go_services.stdout_lines }}"
   become: yes
 
 - name: restart go-server

--- a/roles/server/handlers/main.yml
+++ b/roles/server/handlers/main.yml
@@ -14,7 +14,7 @@
 
 - name: restart go service
   service: "name={{ item | basename }} state=restarted"
-  with_items: go_services.stdout_lines
+  with_items: "{{ go_services.stdout_lines }}"
 
 - name: restart go-server
   become: yes


### PR DESCRIPTION
Fixes #47 
Ansible has removed the support for 'bare variables' in loops;
variables must now be templated. See Ansible changelog for versions 2.0
and 2.2