### PR TITLE
Fix yum repo url.

### DIFF
--- a/roles/common/files/thoughtworks-go-download.repo
+++ b/roles/common/files/thoughtworks-go-download.repo
@@ -2,6 +2,6 @@
 
 [thoughtworks-go-download]
 name=Thoughtworks Go Repository
-baseurl=https://download.go.cd
+baseurl=https://download.gocd.io
 enabled=1
 gpgcheck=0


### PR DESCRIPTION
Fixed yum repo address to new gocd domain (gocd.io).