### PR TITLE
Fix init.d goagent service process handling.

### DIFF
--- a/roles/agent/templates/go-agent-sh
+++ b/roles/agent/templates/go-agent-sh
@@ -138,7 +138,7 @@ export LOG_FILE
 eval stringToArgsArray "$AGENT_BOOTSTRAPPER_ARGS"
 AGENT_BOOTSTRAPPER_ARGS=("${_stringToArgs[@]}")
 
-RUN_CMD=("$(autoDetectJavaExecutable)" "-jar" "$AGENT_DIR/agent-bootstrapper.jar" "-serverUrl" "$(autoDetectGoServerUrl)" "${AGENT_BOOTSTRAPPER_ARGS[@]}")
+RUN_CMD=("$(autoDetectJavaExecutable)" "-Dgo-agent{{ item }}-running" "-jar" "$AGENT_DIR/agent-bootstrapper.jar" "-serverUrl" "$(autoDetectGoServerUrl)" "${AGENT_BOOTSTRAPPER_ARGS[@]}")
 
 echo "[$(date)] Starting Go Agent Bootstrapper with command: ${RUN_CMD[@]}" >>"$STDOUT_LOG_FILE"
 echo "[$(date)] Starting Go Agent Bootstrapper in directory: $AGENT_WORK_DIR" >>"$STDOUT_LOG_FILE"


### PR DESCRIPTION
Fixed goagent init.d script service process handling.

The init.d script (go-agent-service) tries to handle the agent process using pgrep looking for token "go-agent{{ AGENT_NUMBER }}-running". But the process does not have this token in it "full command line", it was there in previous versions of this role, but was removed as the goagent jar does not supported unknow parameters. I fixed it adding the token as a "-D" parameter supported to any jar.