### PR TITLE
Allow the Java version to be overridden

### DIFF
--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -26,3 +26,11 @@ GOCD_SSH_KNOWN_DOMAIN: github.com
 
 # Used internally. Do not change.
 GOCD_VALID_EMAIL_REGEX: '\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}\b'
+
+# Java version and package management
+GOCD_JAVA_VERSION: 7
+GOCD_JAVA_PACKAGE_VERSION_YUM: 1.{{ GOCD_JAVA_VERSION }}.0
+GOCD_JAVA_PACKAGE_YUM: java-{{ GOCD_JAVA_PACKAGE_VERSION_YUM }}-openjdk-devel
+
+GOCD_JAVA_PACKAGE_VERSION_DEB: "{{ GOCD_JAVA_VERSION }}"
+GOCD_JAVA_PACKAGE_DEB: "openjdk-{{ GOCD_JAVA_PACKAGE_VERSION_DEB }}-jdk"

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -3,22 +3,22 @@
   fail: msg='This role only supports Yum or Apt package managers at the moment.  Please do a manual install instead.'
   when: ansible_pkg_mgr != 'yum' and ansible_pkg_mgr != 'apt'
 
-- name: yum install Java 1.7 and some basic dependencies
+- name: "yum install Java {{ GOCD_JAVA_PACKAGE_VERSION_YUM }} and some basic dependencies"
   become: yes
   yum: name={{ item }} state=present
   with_items:
    - unzip
    - which
-   - java-1.7.0-openjdk-devel
+   - "{{ GOCD_JAVA_PACKAGE_YUM }}"
   when: ansible_pkg_mgr == 'yum'
 
-- name: apt install Java 1.7 and some basic dependencies. Must be installed before repo.
+- name: "apt install Java {{ GOCD_JAVA_PACKAGE_VERSION_DEB }} and some basic dependencies. Must be installed before repo."
   become: yes
   apt: name={{ item }} state=present update_cache=true
   with_items:
    - python-pycurl
    - unzip
-   - openjdk-7-jdk
+   - "{{ GOCD_JAVA_PACKAGE_DEB }}"
   when: ansible_pkg_mgr == 'apt'
 
 - name: determine JAVA_HOME


### PR DESCRIPTION
Newer versions of Ubuntu doesn't have jdk7 available anymore so being
able to configure it to use 8 is useful. :)